### PR TITLE
Improve funding amount parsing and remove duplicate imports

### DIFF
--- a/tests/test_threat_scoring.py
+++ b/tests/test_threat_scoring.py
@@ -24,3 +24,13 @@ def test_calculate_threat_score():
     profile = make_profile()
     score = analyzer._calculate_threat_score(profile)
     assert score == 1.0
+
+
+def test_normalize_funding_amount_millions():
+    analyzer = CompetitorAnalyzer
+    assert analyzer._normalize_funding_amount('300M') == 300.0
+
+
+def test_normalize_funding_amount_billions():
+    analyzer = CompetitorAnalyzer
+    assert analyzer._normalize_funding_amount('1.2B') == 1200.0


### PR DESCRIPTION
## Summary
- remove redundant header and import block from `CompetitorAnalyzer`
- parse funding strings with new `_normalize_funding_amount` helper
- add tests for million and billion funding amounts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc7a2aedc8832182e66a85e6a6f39a