### PR TITLE
Add utils package marker and resilient imports

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility package exports for competitor analyzer."""

--- a/src/utils/web_utils.py
+++ b/src/utils/web_utils.py
@@ -16,8 +16,12 @@ import json
 from pathlib import Path
 
 # Import our scraper
-from ..competitor.scraper import WebScraper, ScrapingResult
-from ..competitor.models import WebsiteData, CompetitorProfile
+try:  # pragma: no cover - import resolution depends on installation context
+    from ..competitor.scraper import WebScraper, ScrapingResult
+    from ..competitor.models import WebsiteData, CompetitorProfile
+except ImportError:  # Fallback for top-level package imports
+    from competitor.scraper import WebScraper, ScrapingResult
+    from competitor.models import WebsiteData, CompetitorProfile
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- add a module docstring in `src/utils/__init__.py` to ensure the directory is treated as a package during installation
- guard the scraper/model imports in `src/utils/web_utils.py` with a fallback so the module imports cleanly when used as a top-level package

## Testing
- PYTHONPATH=src python - <<'PY'
import sys
import types

if 'tldextract' not in sys.modules:
    tldextract_stub = types.ModuleType('tldextract')

    class DummyExtractResult:
        def __init__(self, subdomain='', domain='', suffix=''):
            self.subdomain = subdomain
            self.domain = domain
            self.suffix = suffix

    def extract(url):
        return DummyExtractResult()

    tldextract_stub.extract = extract
    sys.modules['tldextract'] = tldextract_stub

competitor_pkg = types.ModuleType('competitor')
competitor_scraper = types.ModuleType('competitor.scraper')
competitor_models = types.ModuleType('competitor.models')

class WebScraper: ...
class ScrapingResult: ...
class WebsiteData: ...
class CompetitorProfile: ...

competitor_scraper.WebScraper = WebScraper
competitor_scraper.ScrapingResult = ScrapingResult
competitor_models.WebsiteData = WebsiteData
competitor_models.CompetitorProfile = CompetitorProfile

competitor_pkg.scraper = competitor_scraper
competitor_pkg.models = competitor_models

sys.modules['competitor'] = competitor_pkg
sys.modules['competitor.scraper'] = competitor_scraper
sys.modules['competitor.models'] = competitor_models

import utils.web_utils as web_utils
print('import succeeded:', web_utils.__name__)
print('WebScraper reference:', web_utils.WebScraper)
print('ScrapingResult reference:', web_utils.ScrapingResult)
print('WebsiteData reference:', web_utils.WebsiteData)
print('CompetitorProfile reference:', web_utils.CompetitorProfile)
PY

------
https://chatgpt.com/codex/tasks/task_e_68cc4b90848083219f8c62f66031a63d