### PR TITLE
Fix competitor threat alias and analysis timestamps

### DIFF
--- a/src/competitor/analyzer.py
+++ b/src/competitor/analyzer.py
@@ -120,8 +120,8 @@ class CompetitorAnalyzer:
                 name=competitor_name,
                 website=competitor_website,
                 target_markets=competitor_config.get('market_segment', []),
-                last_analyzed=datetime.now().isoformat(),
-                threat_level=ThreatLevel(competitor_config.get('competitive_threat', 'medium'))
+                last_analyzed=datetime.now(),
+                competitive_threat=ThreatLevel(competitor_config.get('competitive_threat', 'medium'))
             )
             
             # Collect data from various sources with better error handling

--- a/src/competitor/models.py
+++ b/src/competitor/models.py
@@ -356,7 +356,26 @@ class CompetitorProfile:
             "data_sources_used": [source.value for source in self.data_sources_used],
             "confidence_score": self.confidence_score
         }
-    
+
+    @property
+    def threat_level(self) -> ThreatLevel:
+        """Alias for competitive_threat to maintain backwards compatibility."""
+        return self.competitive_threat
+
+    @threat_level.setter
+    def threat_level(self, value: Union[ThreatLevel, str, None]) -> None:
+        """Allow legacy assignments to map to competitive_threat."""
+        if value is None:
+            self.competitive_threat = ThreatLevel.MEDIUM
+        elif isinstance(value, ThreatLevel):
+            self.competitive_threat = value
+        elif isinstance(value, str):
+            self.competitive_threat = ThreatLevel(value.lower())
+        else:
+            raise TypeError(
+                "Threat level must be a ThreatLevel, string, or None"
+            )
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'CompetitorProfile':
         """Create CompetitorProfile from dictionary."""

--- a/src/competitor/reports/docx_reports.py
+++ b/src/competitor/reports/docx_reports.py
@@ -291,20 +291,25 @@ class DOCXReportGenerator:
         # Basic information table
         table = doc.add_table(rows=5, cols=2)
         table.style = 'Light Shading Accent 1'
-        
+
         # Table content
         table.cell(0, 0).text = 'Website'
         table.cell(0, 1).text = profile.website
-        
+
         table.cell(1, 0).text = 'Threat Level'
         table.cell(1, 1).text = profile.threat_level.value.title() if profile.threat_level else 'Medium'
-        
+
         table.cell(2, 0).text = 'Target Markets'
         table.cell(2, 1).text = ', '.join(profile.target_markets) if profile.target_markets else 'Unknown'
-        
+
         table.cell(3, 0).text = 'Last Analyzed'
-        table.cell(3, 1).text = profile.last_analyzed or 'N/A'
-        
+        last_analyzed_value = profile.last_analyzed
+        if isinstance(last_analyzed_value, datetime):
+            last_analyzed_text = last_analyzed_value.isoformat()
+        else:
+            last_analyzed_text = last_analyzed_value or 'N/A'
+        table.cell(3, 1).text = last_analyzed_text
+
         table.cell(4, 0).text = 'Technology Stack'
         table.cell(4, 1).text = ', '.join(profile.technology_stack) if profile.technology_stack else 'Unknown'
         

--- a/src/competitor/reports/pdf_reports.py
+++ b/src/competitor/reports/pdf_reports.py
@@ -359,14 +359,19 @@ class PDFReportGenerator:
         
         content = []
         content.append(Paragraph(f"Competitor Profile: {profile.name}", heading_style))
-        
+
         # Basic information table
+        last_analyzed_value = profile.last_analyzed
+        if isinstance(last_analyzed_value, datetime):
+            last_analyzed_text = last_analyzed_value.isoformat()
+        else:
+            last_analyzed_text = last_analyzed_value or 'N/A'
         basic_info = [
             ['Attribute', 'Value'],
             ['Website', profile.website],
             ['Threat Level', profile.threat_level.value.title() if profile.threat_level else 'Medium'],
             ['Target Markets', ', '.join(profile.target_markets) if profile.target_markets else 'Unknown'],
-            ['Last Analyzed', profile.last_analyzed or 'N/A']
+            ['Last Analyzed', last_analyzed_text]
         ]
         
         info_table = Table(basic_info, colWidths=[1.5*inch, 4*inch])


### PR DESCRIPTION
## Summary
- instantiate competitor profiles with the `competitive_threat` field and real `datetime` timestamps
- add a `threat_level` property alias on `CompetitorProfile` so legacy reads and writes map to `competitive_threat`
- normalize report rendering to stringify `last_analyzed` values when they are datetimes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc57ff1a2483219b8efbdb7f865627