### PR TITLE
Add helper to persist competitor analysis timestamps

### DIFF
--- a/src/competitor/analyzer.py
+++ b/src/competitor/analyzer.py
@@ -120,7 +120,7 @@ class CompetitorAnalyzer:
                 name=competitor_name,
                 website=competitor_website,
                 target_markets=competitor_config.get('market_segment', []),
-                last_analyzed=datetime.now().isoformat(),
+                last_analyzed=datetime.now(),
                 threat_level=ThreatLevel(competitor_config.get('competitive_threat', 'medium'))
             )
             


### PR DESCRIPTION
## Summary
- convert stored competitor `last_analyzed` values to datetimes when parsing configuration and add an updater that persists refreshed timestamps
- have the analyzer stamp competitor profiles with `datetime` objects so persisted values remain consistent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc57fff9b08321b19a905ebe786e77