### PR TITLE
Add analysis config metadata to intelligence reports

### DIFF
--- a/src/competitor/analyzer.py
+++ b/src/competitor/analyzer.py
@@ -86,8 +86,8 @@ class CompetitorAnalyzer:
         
         # Create intelligence container
         intelligence = CompetitorIntelligence(
-            profiles=profiles,
-            config=self.config.get_analysis_config_object(),
+            competitor_profiles=profiles,
+            analysis_config=self.config.get_analysis_config_object(),
             metadata={
                 'total_competitors_analyzed': len(profiles),
                 'analysis_duration_minutes': round(analysis_duration, 2),

--- a/src/competitor/models.py
+++ b/src/competitor/models.py
@@ -4,12 +4,16 @@ Core data models and schemas for the competitor analysis system.
 Defines the structure for competitor profiles, analysis results, and reports.
 """
 
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Any, Union
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional, Any, Union, TYPE_CHECKING
 from datetime import datetime
 from enum import Enum
 import json
 from pathlib import Path
+
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from .config import AnalysisConfigSummary
 
 
 class ThreatLevel(Enum):
@@ -540,26 +544,62 @@ class CompetitorIntelligence:
     generated_at: datetime = field(default_factory=datetime.now)
     analysis_depth: str = "standard"
     total_competitors: int = 0
-    
+
     # Core Data
     competitor_profiles: List[CompetitorProfile] = field(default_factory=list)
     competitive_matrix: Optional[CompetitiveMatrix] = None
     market_intelligence: Optional[MarketIntelligence] = None
-    
+
+    # Configuration & Metadata
+    analysis_config: Optional['AnalysisConfigSummary'] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
     # Analysis Results
     executive_summary: Optional[str] = None
     key_insights: List[str] = field(default_factory=list)
     strategic_recommendations: List[str] = field(default_factory=list)
     threat_assessment: Dict[str, ThreatLevel] = field(default_factory=dict)
-    
+
     # SWOT Analyses
     overall_swot: Optional[SWOTAnalysis] = None
     competitor_swots: Dict[str, SWOTAnalysis] = field(default_factory=dict)
-    
+
+    def __post_init__(self):
+        """Normalise optional fields and keep derived counts synchronised."""
+        if self.competitor_profiles is None:
+            self.competitor_profiles = []
+
+        if self.metadata is None:
+            self.metadata = {}
+
+        self._synchronise_profile_state()
+
+    # ------------------------------------------------------------------
+    # Compatibility helpers
+    # ------------------------------------------------------------------
+    @property
+    def profiles(self) -> List[CompetitorProfile]:
+        """Alias for ``competitor_profiles`` used by existing callers."""
+        return self.competitor_profiles
+
+    @profiles.setter
+    def profiles(self, value: Optional[List[CompetitorProfile]]) -> None:
+        self.competitor_profiles = list(value) if value else []
+        self._synchronise_profile_state()
+
+    @property
+    def config(self) -> Optional['AnalysisConfigSummary']:
+        """Backward-compatible alias for :attr:`analysis_config`."""
+        return self.analysis_config
+
+    @config.setter
+    def config(self, value: Optional['AnalysisConfigSummary']) -> None:
+        self.analysis_config = value
+
     def add_competitor_profile(self, profile: CompetitorProfile):
         """Add a competitor profile to the intelligence."""
         self.competitor_profiles.append(profile)
-        self.total_competitors = len(self.competitor_profiles)
+        self._synchronise_profile_state()
         self.threat_assessment[profile.name] = profile.competitive_threat
     
     def get_competitor_by_name(self, name: str) -> Optional[CompetitorProfile]:
@@ -583,6 +623,8 @@ class CompetitorIntelligence:
             "competitor_profiles": [profile.to_dict() for profile in self.competitor_profiles],
             "competitive_matrix": self.competitive_matrix.to_dict() if self.competitive_matrix else None,
             "market_intelligence": self.market_intelligence.to_dict() if self.market_intelligence else None,
+            "analysis_config": self._serialize_analysis_config(),
+            "metadata": dict(self.metadata),
             "executive_summary": self.executive_summary,
             "key_insights": self.key_insights,
             "strategic_recommendations": self.strategic_recommendations,
@@ -643,14 +685,18 @@ class CompetitorIntelligence:
             name: SWOTAnalysis(**swot_data)
             for name, swot_data in data.get("competitor_swots", {}).items()
         }
-        
+
+        analysis_config = cls._deserialize_analysis_config(data.get("analysis_config"))
+        metadata = data.get("metadata") or {}
+
         return cls(
             generated_at=generated_at,
             analysis_depth=data.get("analysis_depth", "standard"),
-            total_competitors=data.get("total_competitors", 0),
             competitor_profiles=competitor_profiles,
             competitive_matrix=competitive_matrix,
             market_intelligence=market_intelligence,
+            analysis_config=analysis_config,
+            metadata=metadata,
             executive_summary=data.get("executive_summary"),
             key_insights=data.get("key_insights", []),
             strategic_recommendations=data.get("strategic_recommendations", []),
@@ -658,6 +704,70 @@ class CompetitorIntelligence:
             overall_swot=overall_swot,
             competitor_swots=competitor_swots
         )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _synchronise_profile_state(self) -> None:
+        """Ensure derived metadata stays aligned with profile data."""
+        self.total_competitors = len(self.competitor_profiles)
+
+        updated_assessment: Dict[str, ThreatLevel] = {}
+        for profile in self.competitor_profiles:
+            existing_level = self.threat_assessment.get(profile.name)
+            if isinstance(existing_level, ThreatLevel):
+                updated_assessment[profile.name] = existing_level
+            elif isinstance(existing_level, str):
+                try:
+                    updated_assessment[profile.name] = ThreatLevel(existing_level)
+                except ValueError:
+                    updated_assessment[profile.name] = profile.competitive_threat
+            else:
+                updated_assessment[profile.name] = profile.competitive_threat
+
+        self.threat_assessment = updated_assessment
+
+    def _serialize_analysis_config(self) -> Optional[Dict[str, Any]]:
+        """Return a serialisable representation of the analysis config."""
+        if not self.analysis_config:
+            return None
+
+        config_obj = self.analysis_config
+
+        if isinstance(config_obj, dict):
+            return dict(config_obj)
+
+        if hasattr(config_obj, "to_dict"):
+            return config_obj.to_dict()  # type: ignore[no-any-return]
+
+        if hasattr(config_obj, "__dataclass_fields__"):
+            return asdict(config_obj)
+
+        # Best-effort conversion
+        return dict(config_obj)  # type: ignore[arg-type]
+
+    @classmethod
+    def _deserialize_analysis_config(cls, raw_config: Optional[Dict[str, Any]]) -> Optional['AnalysisConfigSummary']:
+        """Reconstruct the analysis configuration object when possible."""
+        if not raw_config:
+            return None
+
+        if not isinstance(raw_config, dict):
+            return raw_config  # type: ignore[return-value]
+
+        try:
+            from .config import AnalysisConfigSummary, _DepthLevel  # Local import avoids circular deps
+
+            return AnalysisConfigSummary(
+                depth_level=_DepthLevel(raw_config.get("depth_level", "standard")),
+                competitors=raw_config.get("competitors", []),
+                output_formats=raw_config.get("output_formats", []),
+                target_pages=raw_config.get("target_pages", []),
+                data_sources=raw_config.get("data_sources", {}),
+            )
+        except Exception:
+            # Fall back to returning the raw dictionary if reconstruction fails
+            return raw_config  # type: ignore[return-value]
 
 
 # Utility functions for data validation and processing

--- a/src/competitor/reports/docx_reports.py
+++ b/src/competitor/reports/docx_reports.py
@@ -139,8 +139,8 @@ class DOCXReportGenerator:
         doc.add_paragraph(f'Generated: {datetime.now().strftime("%B %d, %Y")}')
         doc.add_paragraph(f'Competitors Analyzed: {len(intelligence.profiles)}')
         
-        if intelligence.config:
-            doc.add_paragraph(f'Analysis Depth: {intelligence.config.depth_level.value.title()}')
+        if intelligence.analysis_config:
+            doc.add_paragraph(f'Analysis Depth: {intelligence.analysis_config.depth_level.value.title()}')
         
         # Competitor list
         doc.add_paragraph()
@@ -407,18 +407,18 @@ class DOCXReportGenerator:
         
         # Analysis configuration
         doc.add_heading('Analysis Configuration', level=2)
-        if intelligence.config:
+        if intelligence.analysis_config:
             config_table = doc.add_table(rows=5, cols=2)
             config_table.style = 'Light List Accent 1'
-            
+
             config_table.cell(0, 0).text = 'Analysis Depth'
-            config_table.cell(0, 1).text = intelligence.config.depth_level.value.title()
-            
+            config_table.cell(0, 1).text = intelligence.analysis_config.depth_level.value.title()
+
             config_table.cell(1, 0).text = 'Competitors'
-            config_table.cell(1, 1).text = ', '.join(intelligence.config.competitors)
-            
+            config_table.cell(1, 1).text = ', '.join(intelligence.analysis_config.competitors)
+
             config_table.cell(2, 0).text = 'Output Formats'
-            config_table.cell(2, 1).text = ', '.join(intelligence.config.output_formats)
+            config_table.cell(2, 1).text = ', '.join(intelligence.analysis_config.output_formats)
             
             config_table.cell(3, 0).text = 'Analysis Date'
             config_table.cell(3, 1).text = intelligence.analysis_date

--- a/src/competitor/reports/json_reports.py
+++ b/src/competitor/reports/json_reports.py
@@ -39,7 +39,7 @@ class JSONReportGenerator:
                 'generated_at': datetime.now().isoformat(),
                 'generator_version': '1.0',
                 'total_competitors': len(intelligence.profiles),
-                'analysis_config': self._serialize_config(intelligence.config) if intelligence.config else {},
+                'analysis_config': self._serialize_config(intelligence.analysis_config) if intelligence.analysis_config else {},
                 'data_sources_used': intelligence.metadata.get('data_sources_used', []),
                 'llm_models_used': intelligence.metadata.get('llm_models_used', {})
             },
@@ -115,27 +115,27 @@ class JSONReportGenerator:
         else:
             return data
     
-    def _serialize_config(self, config) -> Dict[str, Any]:
+    def _serialize_config(self, analysis_config) -> Dict[str, Any]:
         """Serialize analysis configuration"""
-        if not config:
+        if not analysis_config:
             return {}
-        
+
         try:
-            config_dict = asdict(config)
+            config_dict = asdict(analysis_config)
             return config_dict
         except:
             # Fallback for non-dataclass config
             return {
-                'depth_level': getattr(config, 'depth_level', 'standard'),
-                'competitors': getattr(config, 'competitors', []),
-                'output_formats': getattr(config, 'output_formats', []),
+                'depth_level': getattr(analysis_config, 'depth_level', 'standard'),
+                'competitors': getattr(analysis_config, 'competitors', []),
+                'output_formats': getattr(analysis_config, 'output_formats', []),
                 'data_sources': {
-                    'analyze_website': getattr(config, 'analyze_website', True),
-                    'analyze_funding': getattr(config, 'analyze_funding', True),
-                    'analyze_jobs': getattr(config, 'analyze_jobs', True),
-                    'analyze_news': getattr(config, 'analyze_news', True),
-                    'analyze_social': getattr(config, 'analyze_social', True),
-                    'analyze_github': getattr(config, 'analyze_github', True)
+                    'analyze_website': getattr(analysis_config, 'analyze_website', True),
+                    'analyze_funding': getattr(analysis_config, 'analyze_funding', True),
+                    'analyze_jobs': getattr(analysis_config, 'analyze_jobs', True),
+                    'analyze_news': getattr(analysis_config, 'analyze_news', True),
+                    'analyze_social': getattr(analysis_config, 'analyze_social', True),
+                    'analyze_github': getattr(analysis_config, 'analyze_github', True)
                 }
             }
     

--- a/src/competitor/reports/pdf_reports.py
+++ b/src/competitor/reports/pdf_reports.py
@@ -165,8 +165,11 @@ class PDFReportGenerator:
         content.append(Paragraph(f"<b>Generated:</b> {analysis_date}", normal_style))
         content.append(Paragraph(f"<b>Competitors Analyzed:</b> {len(intelligence.profiles)}", normal_style))
         
-        if intelligence.config:
-            content.append(Paragraph(f"<b>Analysis Depth:</b> {intelligence.config.depth_level.value.title()}", normal_style))
+        if intelligence.analysis_config:
+            content.append(Paragraph(
+                f"<b>Analysis Depth:</b> {intelligence.analysis_config.depth_level.value.title()}",
+                normal_style
+            ))
         
         content.append(Spacer(1, 0.3*inch))
         
@@ -487,12 +490,12 @@ class PDFReportGenerator:
         
         # Analysis configuration
         content.append(Paragraph("Analysis Configuration", subheading_style))
-        if intelligence.config:
+        if intelligence.analysis_config:
             config_data = [
                 ['Parameter', 'Value'],
-                ['Analysis Depth', intelligence.config.depth_level.value.title()],
-                ['Competitors Analyzed', ', '.join(intelligence.config.competitors)],
-                ['Output Formats', ', '.join(intelligence.config.output_formats)],
+                ['Analysis Depth', intelligence.analysis_config.depth_level.value.title()],
+                ['Competitors Analyzed', ', '.join(intelligence.analysis_config.competitors)],
+                ['Output Formats', ', '.join(intelligence.analysis_config.output_formats)],
                 ['Analysis Date', intelligence.analysis_date]
             ]
             


### PR DESCRIPTION
## Summary
- add optional analysis_config and metadata fields to CompetitorIntelligence along with compatibility aliases
- ensure analyzer and report generators use the new fields when building intelligence objects and serialising data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc5809c24083219a8fa37925931ecd