### PR TITLE
Normalise data source aliases and add coverage

### DIFF
--- a/src/competitor/config.py
+++ b/src/competitor/config.py
@@ -476,24 +476,41 @@ class CompetitorConfig:
     def is_data_source_enabled(self, source_name: str) -> bool:
         """
         Check if a data source is enabled.
-        
+
         Args:
             source_name: Name of the data source to check
-            
+
         Returns:
             True if enabled, False otherwise
         """
-        source_mapping = {
-            "websites": self.data_sources.company_websites,
-            "funding": self.data_sources.funding_data,
-            "jobs": self.data_sources.job_boards,
-            "news": self.data_sources.news_sources,
-            "social": self.data_sources.social_media,
-            "github": self.data_sources.github_repos,
-            "patents": self.data_sources.patent_databases
+        if not isinstance(source_name, str):  # Defensive guard for unexpected input
+            return False
+
+        normalized_name = source_name.strip().lower().replace("-", "_").replace(" ", "_")
+
+        alias_mapping = {
+            "websites": "company_websites",
+            "company_websites": "company_websites",
+            "funding": "funding_data",
+            "funding_data": "funding_data",
+            "jobs": "job_boards",
+            "job_boards": "job_boards",
+            "news": "news_sources",
+            "news_sources": "news_sources",
+            "social": "social_media",
+            "social_media": "social_media",
+            "github": "github_repos",
+            "github_repos": "github_repos",
+            "patents": "patent_databases",
+            "patent_databases": "patent_databases"
         }
 
-        value = source_mapping.get(source_name)
+        canonical_name = alias_mapping.get(normalized_name, normalized_name)
+
+        if not hasattr(self.data_sources, canonical_name):
+            return False
+
+        value = getattr(self.data_sources, canonical_name)
 
         if isinstance(value, dict):
             return bool(value.get("enabled", False))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import yaml
+
 from competitor.config import CompetitorConfig
 
 
@@ -18,3 +19,53 @@ def test_loads_existing_config(tmp_path):
 
     assert cfg.competitors[0]['name'] == 'TestCo'
     assert cfg.llm_config['provider'] == 'test-provider'
+
+
+def test_is_data_source_enabled_normalises_aliases(tmp_path):
+    """All keys used by CompetitorAnalyzer should resolve to the same setting."""
+    config_path = tmp_path / 'config.yaml'
+    data = {
+        'llm': {'provider': 'test-provider'},
+        'competitors': [],
+        'analysis': {},
+        'output': {},
+        'data_sources': {
+            'company_websites': True,
+            'funding_data': {'enabled': True},
+            'job_boards': {'enabled': False},
+            'news_sources': {'enabled': True},
+            'social_media': {'enabled': False},
+            'github_repos': {'enabled': True},
+            'patent_databases': {'enabled': False},
+        },
+    }
+
+    with open(config_path, 'w', encoding='utf-8') as f:
+        yaml.dump(data, f)
+
+    cfg = CompetitorConfig(config_path=str(config_path))
+
+    status_by_attribute = {
+        'company_websites': True,
+        'funding_data': True,
+        'job_boards': False,
+        'news_sources': True,
+        'social_media': False,
+        'github_repos': True,
+        'patent_databases': False,
+    }
+
+    analyzer_aliases = {
+        'company_websites': ['websites'],
+        'funding_data': ['funding'],
+        'job_boards': ['jobs'],
+        'news_sources': ['news'],
+        'social_media': ['social'],
+        'github_repos': ['github'],
+        'patent_databases': ['patents'],
+    }
+
+    for attr_name, expected in status_by_attribute.items():
+        assert cfg.is_data_source_enabled(attr_name) == expected
+        for alias in analyzer_aliases[attr_name]:
+            assert cfg.is_data_source_enabled(alias) == expected


### PR DESCRIPTION
## Summary
- normalise `CompetitorConfig.is_data_source_enabled` so short and attribute-style names resolve to the same backing setting
- add tests confirming every data source key used by `CompetitorAnalyzer` maps to the expected configuration flag

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc580180fc8321a6e0a0d30ae4e8fb